### PR TITLE
Changes for the upgrade of our Mono.Linker

### DIFF
--- a/linker/Mono.Linker.Steps/LoadReferencesStep.cs
+++ b/linker/Mono.Linker.Steps/LoadReferencesStep.cs
@@ -26,6 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using System;
 using System.Collections;
 
 using Mono.Cecil;
@@ -48,8 +49,17 @@ namespace Mono.Linker.Steps {
 
 			_references.Add (assembly.Name, assembly);
 
-			foreach (AssemblyNameReference reference in assembly.MainModule.AssemblyReferences)
-				ProcessReferences (Context.Resolve (reference));
+			foreach (AssemblyDefinition reference in Context.DependenciesFor(assembly))
+			{
+				try
+				{
+					ProcessReferences(reference);
+				}
+				catch (Exception ex)
+				{
+					throw new Exception(string.Format("Error while processing references of '{0}'", assembly.FullName), ex);
+				}
+			}
 		}
 	}
 }

--- a/linker/Mono.Linker.Steps/MarkStep.cs
+++ b/linker/Mono.Linker.Steps/MarkStep.cs
@@ -554,6 +554,8 @@ namespace Mono.Linker.Steps {
 				MarkMethodsIf (type.Methods, HasSerializationAttribute);
 			}
 
+			MarkTypeAdditionalMarking (type);
+
 			DoAdditionalTypeProcessing (type);
 
 			Annotations.Pop ();
@@ -963,6 +965,8 @@ namespace Mono.Linker.Steps {
 
 			EnqueueMethod (method);
 
+			MarkMethodAdditionalMarking (method);
+
 			Annotations.Pop ();
 			Annotations.AddDependency (method);
 
@@ -1194,7 +1198,15 @@ namespace Mono.Linker.Steps {
 			}
 		}
 
-		protected virtual bool ContinueWith(TypeDefinition type, TypeReference reference)
+		protected virtual void MarkTypeAdditionalMarking (TypeDefinition type)
+		{
+		}
+
+		protected virtual void MarkMethodAdditionalMarking (MethodDefinition method)
+		{
+		}
+
+		protected virtual bool ContinueWith (TypeDefinition type, TypeReference reference)
 		{
 			if (type == null) {
 				throw new ResolutionException (reference);
@@ -1203,7 +1215,7 @@ namespace Mono.Linker.Steps {
 			return true;
 		}
 
-		protected virtual bool ContinueWith(MethodDefinition method, MethodReference reference)
+		protected virtual bool ContinueWith (MethodDefinition method, MethodReference reference)
 		{
 			if (method == null) {
 				throw new ResolutionException (reference);

--- a/linker/Mono.Linker.Steps/MarkStep.cs
+++ b/linker/Mono.Linker.Steps/MarkStep.cs
@@ -970,7 +970,6 @@ namespace Mono.Linker.Steps {
 
 			EnqueueMethod (method);
 
-
 			Annotations.Pop ();
 			Annotations.AddDependency (method);
 

--- a/linker/Mono.Linker.Steps/MarkStep.cs
+++ b/linker/Mono.Linker.Steps/MarkStep.cs
@@ -561,8 +561,6 @@ namespace Mono.Linker.Steps {
 				MarkMethodsIf (type.Methods, HasSerializationAttribute);
 			}
 
-			MarkTypeAdditionalMarking (type);
-
 			DoAdditionalTypeProcessing (type);
 
 			Annotations.Pop ();
@@ -1203,10 +1201,6 @@ namespace Mono.Linker.Steps {
 			default:
 				break;
 			}
-		}
-
-		protected virtual void MarkTypeAdditionalMarking (TypeDefinition type)
-		{
 		}
 
 		protected virtual void MarkMethodAdditionalMarking (MethodDefinition method)

--- a/linker/Mono.Linker.Steps/MarkStep.cs
+++ b/linker/Mono.Linker.Steps/MarkStep.cs
@@ -226,9 +226,10 @@ namespace Mono.Linker.Steps {
 
 			TypeReference constructor_type = ca.Constructor.DeclaringType;
 			TypeDefinition type = constructor_type.Resolve ();
-			if (type == null) {
+
+			if (!ContinueWith (type, constructor_type)) {
 				Annotations.Pop ();
-				throw new ResolutionException (constructor_type);
+				return;
 			}
 
 			MarkCustomAttributeProperties (ca, type);
@@ -513,8 +514,8 @@ namespace Mono.Linker.Steps {
 
 			TypeDefinition type = ResolveTypeDefinition (reference);
 
-			if (type == null)
-				throw new ResolutionException (reference);
+			if (!ContinueWith (type, reference))
+				return null;
 
 			if (CheckProcessed (type))
 				return null;
@@ -952,9 +953,9 @@ namespace Mono.Linker.Steps {
 
 			MethodDefinition method = ResolveMethodDefinition (reference);
 
-			if (method == null) {
+			if (!ContinueWith (method, reference)) {
 				Annotations.Pop ();
-				throw new ResolutionException (reference);
+				return null;
 			}
 
 			if (Annotations.GetAction (method) == MethodAction.Nothing)
@@ -1191,6 +1192,24 @@ namespace Mono.Linker.Steps {
 			default:
 				break;
 			}
+		}
+
+		protected virtual bool ContinueWith(TypeDefinition type, TypeReference reference)
+		{
+			if (type == null) {
+				throw new ResolutionException (reference);
+			}
+
+			return true;
+		}
+
+		protected virtual bool ContinueWith(MethodDefinition method, MethodReference reference)
+		{
+			if (method == null) {
+				throw new ResolutionException (reference);
+			}
+
+			return true;
 		}
 	}
 }

--- a/linker/Mono.Linker.Steps/MarkStep.cs
+++ b/linker/Mono.Linker.Steps/MarkStep.cs
@@ -970,7 +970,6 @@ namespace Mono.Linker.Steps {
 
 			EnqueueMethod (method);
 
-			MarkMethodAdditionalMarking (method);
 
 			Annotations.Pop ();
 			Annotations.AddDependency (method);
@@ -1201,10 +1200,6 @@ namespace Mono.Linker.Steps {
 			default:
 				break;
 			}
-		}
-
-		protected virtual void MarkMethodAdditionalMarking (MethodDefinition method)
-		{
 		}
 
 		protected virtual bool ContinueWith (TypeDefinition type, TypeReference reference)

--- a/linker/Mono.Linker.Steps/MarkStep.cs
+++ b/linker/Mono.Linker.Steps/MarkStep.cs
@@ -147,7 +147,14 @@ namespace Mono.Linker.Steps {
 			while (!QueueIsEmpty ()) {
 				MethodDefinition method = (MethodDefinition) _methods.Dequeue ();
 				Annotations.Push (method);
-				ProcessMethod (method);
+				try
+				{
+					ProcessMethod (method);
+				}
+				catch (Exception e)
+				{
+					throw new Exception (string.Format ("Error processing method: '{0}' in assembly: '{1}'", method.FullName, method.Module.Name), e);
+				}
 				Annotations.Pop ();
 			}
 		}

--- a/linker/Mono.Linker.Steps/ResolveFromAssemblyStep.cs
+++ b/linker/Mono.Linker.Steps/ResolveFromAssemblyStep.cs
@@ -96,7 +96,7 @@ namespace Mono.Linker.Steps {
 					if (!isForwarder)
 						continue;
 					var resolvedExportedType = exported.Resolve ();
-					var resolvedTypeAssembly = context.Resolve (resolvedExportedType.Scope);
+					context.Resolve (resolvedExportedType.Scope);
 					MarkType (context, resolvedExportedType);
 					context.Annotations.Mark (exported);
 					if (context.KeepTypeForwarderOnlyAssemblies) {

--- a/linker/Mono.Linker.Steps/ResolveFromXmlStep.cs
+++ b/linker/Mono.Linker.Steps/ResolveFromXmlStep.cs
@@ -399,8 +399,7 @@ namespace Mono.Linker.Steps {
 
 		static void ProcessReferences (AssemblyDefinition assembly, LinkContext context)
 		{
-			foreach (AssemblyNameReference name in assembly.MainModule.AssemblyReferences)
-				context.Resolve (name);
+			context.DependenciesFor (assembly);
 		}
 
 		static bool IsRequired (XPathNavigator nav)

--- a/linker/Mono.Linker.Steps/ResolveStep.cs
+++ b/linker/Mono.Linker.Steps/ResolveStep.cs
@@ -34,7 +34,7 @@ namespace Mono.Linker.Steps {
 
 		ArrayList _unResolved;
 
-		internal ResolveStep ()
+		protected ResolveStep ()
 		{
 			_unResolved = new ArrayList ();
 		}

--- a/linker/Mono.Linker.Steps/SweepStep.cs
+++ b/linker/Mono.Linker.Steps/SweepStep.cs
@@ -127,8 +127,8 @@ namespace Mono.Linker.Steps {
 			var references = assembly.MainModule.AssemblyReferences;
 			for (int i = 0; i < references.Count; i++) {
 				var reference = references [i];
-				var r = Context.Resolver.Resolve (reference);
-				if (!AreSameReference (r.Name, target.Name))
+				var r = Context.Resolver.ResolveName(reference);
+				if (!AreSameReference (r, target.Name))
 					continue;
 
 				references.RemoveAt (i);

--- a/linker/Mono.Linker.Steps/SweepStep.cs
+++ b/linker/Mono.Linker.Steps/SweepStep.cs
@@ -203,7 +203,7 @@ namespace Mono.Linker.Steps {
 			return changes;
 		}
 
-		void SweepType (TypeDefinition type)
+		protected virtual void SweepType (TypeDefinition type)
 		{
 			if (type.HasFields)
 				SweepCollection (type.Fields);
@@ -215,7 +215,7 @@ namespace Mono.Linker.Steps {
 				SweepNestedTypes (type);
 		}
 
-		void SweepNestedTypes (TypeDefinition type)
+		protected void SweepNestedTypes (TypeDefinition type)
 		{
 			for (int i = 0; i < type.NestedTypes.Count; i++) {
 				var nested = type.NestedTypes [i];
@@ -275,7 +275,7 @@ namespace Mono.Linker.Steps {
 			}
 		}
 
-		void SweepCollection (IList list)
+		protected void SweepCollection (IList list)
 		{
 			for (int i = 0; i < list.Count; i++)
 				if (!Annotations.IsMarked ((IMetadataTokenProvider) list [i]))

--- a/linker/Mono.Linker.Steps/SweepStep.cs
+++ b/linker/Mono.Linker.Steps/SweepStep.cs
@@ -169,6 +169,8 @@ namespace Mono.Linker.Steps {
 			foreach (TypeReference tr in assembly.MainModule.GetTypeReferences ()) {
 				if (hash.ContainsKey (tr))
 					continue;
+				if (!CanChangeScope (tr))
+					continue;
 				var td = tr.Resolve ();
 				IMetadataScope scope = tr.Scope;
 				// at this stage reference might include things that can't be resolved
@@ -280,6 +282,11 @@ namespace Mono.Linker.Steps {
 			for (int i = 0; i < list.Count; i++)
 				if (!Annotations.IsMarked ((IMetadataTokenProvider) list [i]))
 					list.RemoveAt (i--);
+		}
+
+		protected virtual bool CanChangeScope(TypeReference type)
+		{
+			return true;
 		}
 
 		static bool AreSameReference (AssemblyNameReference a, AssemblyNameReference b)

--- a/linker/Mono.Linker.Steps/TypeMapStep.cs
+++ b/linker/Mono.Linker.Steps/TypeMapStep.cs
@@ -72,7 +72,7 @@ namespace Mono.Linker.Steps {
 					if (@base == null)
 						continue;
 
-					Annotations.AddPreservedMethod (type, @base);
+					AnnotateMethods (method, @base);
 				}
 			}
 		}

--- a/linker/Mono.Linker.Steps/TypeMapStep.cs
+++ b/linker/Mono.Linker.Steps/TypeMapStep.cs
@@ -210,6 +210,9 @@ namespace Mono.Linker.Steps {
 			if (cp.Count != mp.Count)
 				return false;
 
+			if (candidate.GenericParameters.Count != method.GenericParameters.Count)
+				return false;
+
 			for (int i = 0; i < cp.Count; i++) {
 				if (!TypeMatch (candidate.GetParameterType (i), method.GetParameterType (i), ref genericParameters))
 					return false;

--- a/linker/Mono.Linker.csproj
+++ b/linker/Mono.Linker.csproj
@@ -11,12 +11,13 @@
     <RootNamespace>Mono.Linker</RootNamespace>
     <AssemblyName>monolinker</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <OutputPath>../../build/</OutputPath>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -24,7 +25,6 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>True</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/linker/Mono.Linker.csproj
+++ b/linker/Mono.Linker.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Mono.Linker\MethodAction.cs" />
     <Compile Include="Mono.Linker\Pipeline.cs" />
     <Compile Include="Mono.Linker\TypePreserve.cs" />
+    <Compile Include="Mono.Linker\Utilities.cs" />
     <Compile Include="Mono.Linker\XApiReader.cs" />
     <Compile Include="Mono.Linker.Steps\TypeMapStep.cs" />
   </ItemGroup>

--- a/linker/Mono.Linker.csproj
+++ b/linker/Mono.Linker.csproj
@@ -48,6 +48,7 @@
     <Compile Include="Mono.Linker.Steps\CleanStep.cs" />
     <Compile Include="Mono.Linker.Steps\RegenerateGuidStep.cs" />
     <Compile Include="Mono.Linker.Steps\LoadI18nAssemblies.cs" />
+    <Compile Include="Mono.Linker\ILinkerAssemblyResolver.cs" />
     <Compile Include="Mono.Linker\IXApiVisitor.cs" />
     <Compile Include="Mono.Linker\I18nAssemblies.cs" />
     <Compile Include="Mono.Linker.Steps\IStep.cs" />

--- a/linker/Mono.Linker.csproj
+++ b/linker/Mono.Linker.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="14.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -41,6 +41,10 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
+    <Reference Include="Mono.Cecil, Version=0.10.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\external\cecil\Mono.Cecil.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Mono.Linker.Steps\BaseStep.cs" />
@@ -95,11 +99,5 @@
   <ItemGroup>
     <None Include="Makefile" />
     <None Include="README" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\cecil\Mono.Cecil.csproj">
-      <Project>{D68133BD-1E63-496E-9EDE-4FBDBF77B486}</Project>
-      <Name>Mono.Cecil</Name>
-    </ProjectReference>
   </ItemGroup>
 </Project>

--- a/linker/Mono.Linker/Annotations.cs
+++ b/linker/Mono.Linker/Annotations.cs
@@ -56,6 +56,18 @@ namespace Mono.Linker {
 		System.Xml.XmlWriter writer;
 		GZipStream zipStream;
 
+		public void Clear ()
+		{
+			method_actions.Clear ();
+			marked.RemoveWhere (m => m is MethodReference);
+			processed.Clear ();
+			preserved_types.Clear ();
+			preserved_methods.Clear ();
+			public_api.Clear ();
+			override_methods.Clear ();
+			base_methods.Clear ();
+		}
+
 		public void PrepareDependenciesDump ()
 		{
 			PrepareDependenciesDump ("linker-dependencies.xml.gz");

--- a/linker/Mono.Linker/Annotations.cs
+++ b/linker/Mono.Linker/Annotations.cs
@@ -90,6 +90,11 @@ namespace Mono.Linker {
 			writer.WriteEndAttribute ();
 		}
 
+		public ICollection<AssemblyDefinition> GetAssemblies()
+		{
+			return assembly_actions.Keys;
+		}
+
 		public AssemblyAction GetAction (AssemblyDefinition assembly)
 		{
 			AssemblyAction action;

--- a/linker/Mono.Linker/Annotations.cs
+++ b/linker/Mono.Linker/Annotations.cs
@@ -139,7 +139,31 @@ namespace Mono.Linker {
 
 		public void SetPreserve (TypeDefinition type, TypePreserve preserve)
 		{
-			preserved_types [type] = preserve;
+			if (preserved_types.ContainsKey(type))
+				preserved_types[type] = ChoosePreserveActionWhichPreservesTheMost(preserved_types[type], preserve);
+			else
+				preserved_types[type] = preserve;
+		}
+
+		public static TypePreserve ChoosePreserveActionWhichPreservesTheMost(TypePreserve leftPreserveAction, TypePreserve rightPreserveAction)
+		{
+			if (leftPreserveAction == rightPreserveAction)
+				return leftPreserveAction;
+
+			if (leftPreserveAction == TypePreserve.All || rightPreserveAction == TypePreserve.All)
+				return TypePreserve.All;
+
+			if (leftPreserveAction == TypePreserve.Nothing && rightPreserveAction != TypePreserve.Nothing)
+				return rightPreserveAction;
+
+			if (rightPreserveAction == TypePreserve.Nothing && leftPreserveAction != TypePreserve.Nothing)
+				return leftPreserveAction;
+
+			if ((leftPreserveAction == TypePreserve.Methods && rightPreserveAction == TypePreserve.Fields) ||
+				(leftPreserveAction == TypePreserve.Fields && rightPreserveAction == TypePreserve.Methods))
+				return TypePreserve.All;
+
+			return rightPreserveAction;
 		}
 
 		public TypePreserve GetPreserve (TypeDefinition type)

--- a/linker/Mono.Linker/AssemblyResolver.cs
+++ b/linker/Mono.Linker/AssemblyResolver.cs
@@ -68,5 +68,10 @@ namespace Mono.Linker {
 			base.AddSearchDirectory (Path.GetDirectoryName (assembly.MainModule.FileName));
 			return assembly;
 		}
+
+		public AssemblyNameReference ResolveName(AssemblyNameReference name)
+		{
+			return Resolve(name).Name;
+		}
 	}
 }

--- a/linker/Mono.Linker/AssemblyResolver.cs
+++ b/linker/Mono.Linker/AssemblyResolver.cs
@@ -33,7 +33,7 @@ using Mono.Cecil;
 
 namespace Mono.Linker {
 
-	public class AssemblyResolver : BaseAssemblyResolver {
+	public class AssemblyResolver : BaseAssemblyResolver, ILinkerAssemblyResolver {
 
 		IDictionary _assemblies;
 
@@ -62,10 +62,11 @@ namespace Mono.Linker {
 			return asm;
 		}
 
-		public void CacheAssembly (AssemblyDefinition assembly)
+		public AssemblyDefinition CacheAssembly (AssemblyDefinition assembly)
 		{
 			_assemblies [assembly.Name.Name] = assembly;
 			base.AddSearchDirectory (Path.GetDirectoryName (assembly.MainModule.FileName));
+			return assembly;
 		}
 	}
 }

--- a/linker/Mono.Linker/Driver.cs
+++ b/linker/Mono.Linker/Driver.cs
@@ -129,17 +129,17 @@ namespace Mono.Linker {
 					break;
 				case 'x':
 					foreach (string file in GetFiles (GetParam ()))
-						p.PrependStep (new ResolveFromXmlStep (new XPathDocument (file)));
+						AddResolutionStep (p, new ResolveFromXmlStep (new XPathDocument (file)));
 					resolver = true;
 					break;
 				case 'a':
 					foreach (string file in GetFiles (GetParam ()))
-						p.PrependStep (new ResolveFromAssemblyStep (file));
+						AddResolutionStep (p, new ResolveFromAssemblyStep (file));
 					resolver = true;
 					break;
 				case 'i':
 					foreach (string file in GetFiles (GetParam ()))
-						p.PrependStep (new ResolveFromXApiStep (new XPathDocument (file)));
+						AddResolutionStep (p, new ResolveFromXApiStep (new XPathDocument (file)));
 					resolver = true;
 					break;
 				case 'l':
@@ -170,6 +170,11 @@ namespace Mono.Linker {
 			p.AddStepAfter (typeof (LoadReferencesStep), new LoadI18nAssemblies (assemblies));
 
 			p.Process (context);
+		}
+
+		protected virtual void AddResolutionStep(Pipeline p, IStep resolveStep)
+		{
+			p.PrependStep (resolveStep);
 		}
 
 		static void AddCustomStep (Pipeline pipeline, string arg)

--- a/linker/Mono.Linker/Driver.cs
+++ b/linker/Mono.Linker/Driver.cs
@@ -177,7 +177,7 @@ namespace Mono.Linker {
 			p.PrependStep (resolveStep);
 		}
 
-		static void AddCustomStep (Pipeline pipeline, string arg)
+		protected void AddCustomStep (Pipeline pipeline, string arg)
 		{
 			int pos = arg.IndexOf (":");
 			if (pos == -1) {
@@ -238,7 +238,7 @@ namespace Mono.Linker {
 			return (string []) lines.ToArray (typeof (string));
 		}
 
-		static I18nAssemblies ParseI18n (string str)
+		protected I18nAssemblies ParseI18n (string str)
 		{
 			I18nAssemblies assemblies = I18nAssemblies.None;
 			string [] parts = str.Split (',');

--- a/linker/Mono.Linker/ILinkerAssemblyResolver.cs
+++ b/linker/Mono.Linker/ILinkerAssemblyResolver.cs
@@ -15,5 +15,7 @@ namespace Mono.Linker
 		void AddSearchDirectory(string directory);
 
 		AssemblyDefinition CacheAssembly(AssemblyDefinition assembly);
+
+		AssemblyNameReference ResolveName(AssemblyNameReference name);
 	}
 }

--- a/linker/Mono.Linker/ILinkerAssemblyResolver.cs
+++ b/linker/Mono.Linker/ILinkerAssemblyResolver.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -9,6 +10,8 @@ namespace Mono.Linker
 {
 	public interface ILinkerAssemblyResolver : IAssemblyResolver
 	{
+		IDictionary AssemblyCache { get; }
+
 		void AddSearchDirectory(string directory);
 
 		AssemblyDefinition CacheAssembly(AssemblyDefinition assembly);

--- a/linker/Mono.Linker/ILinkerAssemblyResolver.cs
+++ b/linker/Mono.Linker/ILinkerAssemblyResolver.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Mono.Cecil;
+
+namespace Mono.Linker
+{
+	public interface ILinkerAssemblyResolver : IAssemblyResolver
+	{
+		void AddSearchDirectory(string directory);
+
+		AssemblyDefinition CacheAssembly(AssemblyDefinition assembly);
+	}
+}

--- a/linker/Mono.Linker/LinkContext.cs
+++ b/linker/Mono.Linker/LinkContext.cs
@@ -259,9 +259,9 @@ namespace Mono.Linker {
 
 		public AssemblyDefinition [] GetAssemblies ()
 		{
-			IDictionary cache = _resolver.AssemblyCache;
-			AssemblyDefinition [] asms = new AssemblyDefinition [cache.Count];
-			cache.Values.CopyTo (asms, 0);
+			var assemblies = Annotations.GetAssemblies();
+			AssemblyDefinition [] asms = new AssemblyDefinition [assemblies.Count];
+			assemblies.CopyTo (asms, 0);
 			return asms;
 		}
 

--- a/linker/Mono.Linker/LinkContext.cs
+++ b/linker/Mono.Linker/LinkContext.cs
@@ -155,8 +155,7 @@ namespace Mono.Linker {
 		{
 			if (File.Exists (name)) {
 				AssemblyDefinition assembly = AssemblyDefinition.ReadAssembly (name, _readerParameters);
-				_resolver.CacheAssembly (assembly);
-				return assembly;
+				return _resolver.CacheAssembly (assembly);
 			}
 
 			return Resolve (new AssemblyNameReference (name, new Version ()));

--- a/linker/Mono.Linker/LinkContext.cs
+++ b/linker/Mono.Linker/LinkContext.cs
@@ -90,6 +90,10 @@ namespace Mono.Linker {
 			get { return _resolver; }
 		}
 
+		public ReaderParameters ReaderParameters {
+			get { return _readerParameters; }
+		}
+
 		public ISymbolReaderProvider SymbolReaderProvider {
 			get { return _symbolReaderProvider; }
 			set { _symbolReaderProvider = value; }
@@ -107,16 +111,22 @@ namespace Mono.Linker {
 		{
 		}
 
-		public LinkContext (Pipeline pipeline, AssemblyResolver resolver)
+		public LinkContext(Pipeline pipeline, AssemblyResolver resolver)
+			: this(pipeline, resolver, new ReaderParameters
+			{
+				AssemblyResolver = resolver,
+			})
+		{
+		}
+
+		public LinkContext (Pipeline pipeline, AssemblyResolver resolver, ReaderParameters readerParameters)
 		{
 			_pipeline = pipeline;
 			_resolver = resolver;
 			_actions = new Hashtable ();
 			_parameters = new Hashtable ();
 			_annotations = new AnnotationStore ();
-			_readerParameters = new ReaderParameters {
-				AssemblyResolver = _resolver,
-			};
+			_readerParameters = readerParameters;
 		}
 
 		public TypeDefinition GetType (string fullName)

--- a/linker/Mono.Linker/LinkContext.cs
+++ b/linker/Mono.Linker/LinkContext.cs
@@ -116,17 +116,18 @@ namespace Mono.Linker {
 			: this(pipeline, resolver, new ReaderParameters
 			{
 				AssemblyResolver = resolver,
-			})
+			},
+			new AnnotationStore ())
 		{
 		}
 
-		public LinkContext (Pipeline pipeline, ILinkerAssemblyResolver resolver, ReaderParameters readerParameters)
+		public LinkContext (Pipeline pipeline, ILinkerAssemblyResolver resolver, ReaderParameters readerParameters, AnnotationStore annotations)
 		{
 			_pipeline = pipeline;
 			_resolver = resolver;
 			_actions = new Hashtable ();
 			_parameters = new Hashtable ();
-			_annotations = new AnnotationStore ();
+			_annotations = annotations;
 			_readerParameters = readerParameters;
 		}
 
@@ -189,7 +190,7 @@ namespace Mono.Linker {
 			return !_annotations.HasAction (assembly);
 		}
 
-		public void SafeReadSymbols (AssemblyDefinition assembly)
+		public virtual void SafeReadSymbols (AssemblyDefinition assembly)
 		{
 			if (!_linkSymbols)
 				return;

--- a/linker/Mono.Linker/LinkContext.cs
+++ b/linker/Mono.Linker/LinkContext.cs
@@ -28,8 +28,9 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.IO;
-
+using System.Linq;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 
@@ -176,6 +177,11 @@ namespace Mono.Linker {
 			catch {
 				throw new AssemblyResolutionException (reference);
 			}
+		}
+
+		public virtual ICollection<AssemblyDefinition> DependenciesFor(AssemblyDefinition assembly)
+		{
+			return assembly.MainModule.AssemblyReferences.Select(Resolve).ToList();
 		}
 
 		protected bool SeenFirstTime (AssemblyDefinition assembly)

--- a/linker/Mono.Linker/LinkContext.cs
+++ b/linker/Mono.Linker/LinkContext.cs
@@ -45,7 +45,7 @@ namespace Mono.Linker {
 		bool _linkSymbols;
 		bool _keepTypeForwarderOnlyAssemblies;
 
-		AssemblyResolver _resolver;
+		ILinkerAssemblyResolver _resolver;
 
 		ReaderParameters _readerParameters;
 		ISymbolReaderProvider _symbolReaderProvider;
@@ -86,7 +86,7 @@ namespace Mono.Linker {
 			get { return _actions; }
 		}
 
-		public AssemblyResolver Resolver {
+		public ILinkerAssemblyResolver Resolver {
 			get { return _resolver; }
 		}
 
@@ -111,7 +111,7 @@ namespace Mono.Linker {
 		{
 		}
 
-		public LinkContext(Pipeline pipeline, AssemblyResolver resolver)
+		public LinkContext(Pipeline pipeline, ILinkerAssemblyResolver resolver)
 			: this(pipeline, resolver, new ReaderParameters
 			{
 				AssemblyResolver = resolver,
@@ -119,7 +119,7 @@ namespace Mono.Linker {
 		{
 		}
 
-		public LinkContext (Pipeline pipeline, AssemblyResolver resolver, ReaderParameters readerParameters)
+		public LinkContext (Pipeline pipeline, ILinkerAssemblyResolver resolver, ReaderParameters readerParameters)
 		{
 			_pipeline = pipeline;
 			_resolver = resolver;

--- a/linker/Mono.Linker/LinkContext.cs
+++ b/linker/Mono.Linker/LinkContext.cs
@@ -178,7 +178,7 @@ namespace Mono.Linker {
 			}
 		}
 
-		bool SeenFirstTime (AssemblyDefinition assembly)
+		protected bool SeenFirstTime (AssemblyDefinition assembly)
 		{
 			return !_annotations.HasAction (assembly);
 		}
@@ -216,7 +216,7 @@ namespace Mono.Linker {
 			return reference;
 		}
 
-		void SetAction (AssemblyDefinition assembly)
+		protected void SetAction (AssemblyDefinition assembly)
 		{
 			AssemblyAction action = AssemblyAction.Link;
 

--- a/linker/Mono.Linker/Pipeline.cs
+++ b/linker/Mono.Linker/Pipeline.cs
@@ -65,6 +65,18 @@ namespace Mono.Linker {
 			throw new InvalidOperationException (msg);
 		}
 
+		public void AddStepBefore(IStep target, IStep step)
+		{
+			for (int i = 0; i < _steps.Count; i++)
+			{
+				if (_steps[i] == target)
+				{
+					_steps.Insert(i, step);
+					return;
+				}
+			}
+		}
+
 		public void ReplaceStep (Type target, IStep step)
 		{
 			AddStepBefore (target, step);

--- a/linker/Mono.Linker/Utilities.cs
+++ b/linker/Mono.Linker/Utilities.cs
@@ -1,0 +1,243 @@
+﻿using Mono.Cecil;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Mono.Linker
+{
+	static class Utilities
+	{
+		internal static TypeReference GetBaseType(this TypeReference type)
+		{
+			if (type == null)
+				return null;
+
+			if (type is TypeSpecification)
+			{
+				if (type.IsGenericParameter || type.IsByReference || type.IsPointer)
+					return null;
+
+				var sentinelType = type as SentinelType;
+				if (sentinelType != null)
+					return sentinelType.ElementType.GetBaseType();
+
+				var pinnedType = type as PinnedType;
+				if (pinnedType != null)
+					return pinnedType.ElementType.GetBaseType();
+
+				var requiredModifierType = type as RequiredModifierType;
+				if (requiredModifierType != null)
+					return requiredModifierType.ElementType.GetBaseType();
+
+				var genericInstance = type as GenericInstanceType;
+				if (genericInstance != null)
+				{
+					var baseType = type.Resolve().BaseType;
+					var baseTypeGenericInstance = baseType as GenericInstanceType;
+
+					if (baseTypeGenericInstance != null)
+						return InflateGenericType(genericInstance, baseType);
+
+					return baseType;
+				}
+			}
+
+			return type.Resolve().BaseType;
+		}
+
+		internal static IEnumerable<TypeReference> GetInterfaces(this TypeReference typeRef)
+		{
+			var typeDef = typeRef.Resolve();
+
+			if (!typeDef.HasInterfaces)
+				yield break;
+
+			var genericInstance = typeRef as GenericInstanceType;
+			if (genericInstance != null)
+			{
+				foreach (var interfaceImpl in typeDef.Interfaces)
+					yield return InflateGenericType(genericInstance, interfaceImpl.InterfaceType);
+			}
+			else
+			{
+				foreach (var interfaceImpl in typeDef.Interfaces)
+					yield return interfaceImpl.InterfaceType;
+			}
+		}
+
+		internal static TypeReference InflateGenericType(GenericInstanceType genericInstanceProvider, TypeReference typeToInflate)
+		{
+			var arrayType = typeToInflate as ArrayType;
+			if (arrayType != null)
+			{
+				var inflatedElementType = InflateGenericType(genericInstanceProvider, arrayType.ElementType);
+
+				if (inflatedElementType != arrayType.ElementType)
+					return new ArrayType(inflatedElementType, arrayType.Rank);
+
+				return arrayType;
+			}
+
+			var genericInst = typeToInflate as GenericInstanceType;
+			if (genericInst != null)
+				return MakeGenericType(genericInstanceProvider, genericInst);
+
+			var genericParameter = typeToInflate as GenericParameter;
+			if (genericParameter != null)
+			{
+				if (genericParameter.Owner is MethodReference)
+					return genericParameter;
+
+				var elementType = genericInstanceProvider.ElementType.Resolve();
+				var parameter = elementType.GenericParameters.Single(p => p == genericParameter);
+				return genericInstanceProvider.GenericArguments[parameter.Position];
+			}
+
+			var functionPointerType = typeToInflate as FunctionPointerType;
+			if (functionPointerType != null)
+			{
+				var result = new FunctionPointerType();
+				result.ReturnType = InflateGenericType(genericInstanceProvider, functionPointerType.ReturnType);
+
+				for (int i = 0; i < functionPointerType.Parameters.Count; i++)
+				{
+					var inflatedParameterType = InflateGenericType(genericInstanceProvider, functionPointerType.Parameters[i].ParameterType);
+					result.Parameters.Add(new ParameterDefinition(inflatedParameterType));
+				}
+
+				return result;
+			}
+
+			var modifierType = typeToInflate as IModifierType;
+			if (modifierType != null)
+			{
+				var modifier = InflateGenericType(genericInstanceProvider, modifierType.ModifierType);
+				var elementType = InflateGenericType(genericInstanceProvider, modifierType.ElementType);
+
+				if (modifierType is OptionalModifierType)
+				{
+					return new OptionalModifierType(modifier, elementType);
+				}
+
+				return new RequiredModifierType(modifier, elementType);
+			}
+
+			var pinnedType = typeToInflate as PinnedType;
+			if (pinnedType != null)
+			{
+				var elementType = InflateGenericType(genericInstanceProvider, pinnedType.ElementType);
+
+				if (elementType != pinnedType.ElementType)
+					return new PinnedType(elementType);
+
+				return pinnedType;
+			}
+
+			var pointerType = typeToInflate as PointerType;
+			if (pointerType != null)
+			{
+				var elementType = InflateGenericType(genericInstanceProvider, pointerType.ElementType);
+
+				if (elementType != pointerType.ElementType)
+					return new PointerType(elementType);
+
+				return pointerType;
+			}
+
+			var byReferenceType = typeToInflate as ByReferenceType;
+			if (byReferenceType != null)
+			{
+				var elementType = InflateGenericType(genericInstanceProvider, byReferenceType.ElementType);
+
+				if (elementType != byReferenceType.ElementType)
+					return new ByReferenceType(elementType);
+
+				return byReferenceType;
+			}
+
+			var sentinelType = typeToInflate as SentinelType;
+			if (sentinelType != null)
+			{
+				var elementType = InflateGenericType(genericInstanceProvider, sentinelType.ElementType);
+
+				if (elementType != sentinelType.ElementType)
+					return new SentinelType(elementType);
+
+				return sentinelType;
+			}
+
+			return typeToInflate;
+		}
+
+		internal static GenericInstanceType MakeGenericType(GenericInstanceType genericInstanceProvider, GenericInstanceType type)
+		{
+			var result = new GenericInstanceType(type.ElementType);
+
+			for (var i = 0; i < type.GenericArguments.Count; ++i)
+			{
+				result.GenericArguments.Add(InflateGenericType(genericInstanceProvider, type.GenericArguments[i]));
+			}
+
+			return result;
+		}
+
+		internal static IEnumerable<MethodReference> GetMethods(this TypeReference type)
+		{
+			var typeDef = type.Resolve();
+
+			if (!typeDef.HasMethods)
+				yield break;
+
+			var genericInstanceType = type as GenericInstanceType;
+			if (genericInstanceType != null)
+			{
+				foreach (var methodDef in typeDef.Methods)
+					yield return MakeMethodReferenceForGenericInstanceType(genericInstanceType, methodDef);
+			}
+			else
+			{
+				foreach (var method in typeDef.Methods)
+					yield return method;
+			}
+		}
+
+		internal static MethodReference MakeMethodReferenceForGenericInstanceType(GenericInstanceType genericInstanceType, MethodDefinition methodDef)
+		{
+			var method = new MethodReference(methodDef.Name, methodDef.ReturnType, genericInstanceType)
+			{
+				HasThis = methodDef.HasThis,
+				ExplicitThis = methodDef.ExplicitThis,
+				CallingConvention = methodDef.CallingConvention
+			};
+
+			foreach (var parameter in methodDef.Parameters)
+				method.Parameters.Add(new ParameterDefinition(parameter.Name, parameter.Attributes, parameter.ParameterType));
+
+			foreach (var gp in methodDef.GenericParameters)
+				method.GenericParameters.Add(new GenericParameter(gp.Name, method));
+
+			return method;
+		}
+
+		internal static TypeReference GetReturnType(this MethodReference method)
+		{
+			var genericInstance = method.DeclaringType as GenericInstanceType;
+
+			if (genericInstance != null)
+				return InflateGenericType(genericInstance, method.ReturnType);
+
+			return method.ReturnType;
+		}
+
+		internal static TypeReference GetParameterType(this MethodReference method, int parameterIndex)
+		{
+			var genericInstance = method.DeclaringType as GenericInstanceType;
+
+			if (genericInstance != null)
+				return InflateGenericType(genericInstance, method.Parameters[parameterIndex].ParameterType);
+
+			return method.Parameters[parameterIndex].ParameterType;
+		}
+	}
+}


### PR DESCRIPTION
This PR contains all of the changes necessary for us to upgrade our Mono.Linker.  This includes

* Refactoring that enables our classes in UnityLinker to derive from/access necessary members in Mono.Linker

* A few new extension points were added for our classes in UnityLinker to hook in to

* Fixes from a few bugs we have corrected (these will be upstreamed later)

* A few improvements we made to error reporting

* Change Mono.Linker.csproj to reference cecil from the location it can be found in il2cpp