### PR TITLE
WIP: Dependency refactoring

### DIFF
--- a/linker/Mono.Linker.Steps/BaseStep.cs
+++ b/linker/Mono.Linker.Steps/BaseStep.cs
@@ -44,6 +44,8 @@ namespace Mono.Linker.Steps {
 
 		public MarkingHelpers MarkingHelpers => _context.MarkingHelpers;
 
+		public Dependencies Dependencies => _context.Dependencies;
+
 		public void Process (LinkContext context)
 		{
 			_context = context;

--- a/linker/Mono.Linker.Steps/OutputStep.cs
+++ b/linker/Mono.Linker.Steps/OutputStep.cs
@@ -71,7 +71,7 @@ namespace Mono.Linker.Steps {
 		protected override void Process ()
 		{
 			CheckOutputDirectory ();
-			Annotations.SaveDependencies ();
+			Dependencies.SaveDependencies ();
 		}
 
 		void CheckOutputDirectory ()
@@ -117,11 +117,11 @@ namespace Mono.Linker.Steps {
 			case AssemblyAction.Save:
 			case AssemblyAction.Link:
 			case AssemblyAction.AddBypassNGen:
-				Context.Annotations.AddDependency (assembly);
+				Context.Dependencies.AddDependency (assembly);
 				WriteAssembly (assembly, directory);
 				break;
 			case AssemblyAction.Copy:
-				Context.Annotations.AddDependency (assembly);
+				Context.Dependencies.AddDependency (assembly);
 				CloseSymbols (assembly);
 				CopyAssembly (GetOriginalAssemblyFileInfo (assembly), directory, Context.LinkSymbols);
 				break;

--- a/linker/Mono.Linker.Steps/ResolveFromAssemblyStep.cs
+++ b/linker/Mono.Linker.Steps/ResolveFromAssemblyStep.cs
@@ -101,7 +101,7 @@ namespace Mono.Linker.Steps
 			var action = rootVisibility == RootVisibility.Any ? AssemblyAction.Copy : AssemblyAction.Link;
 			SetAction (context, assembly, action);
 
-			context.Annotations.Push (assembly);
+			context.Dependencies.Push (assembly);
 
 			foreach (TypeDefinition type in assembly.MainModule.Types)
 				MarkType (context, type, rootVisibility);
@@ -148,7 +148,7 @@ namespace Mono.Linker.Steps
 				}
 			}
 
-			context.Annotations.Pop ();
+			context.Dependencies.Pop ();
 		}
 
 		static void MarkType (LinkContext context, TypeDefinition type, RootVisibility rootVisibility)
@@ -174,7 +174,7 @@ namespace Mono.Linker.Steps
 
 			context.Annotations.Mark (type);
 
-			context.Annotations.Push (type);
+			context.Dependencies.Push (type);
 
 			if (type.HasFields)
 				MarkFields (context, type.Fields, rootVisibility);
@@ -184,20 +184,20 @@ namespace Mono.Linker.Steps
 				foreach (var nested in type.NestedTypes)
 					MarkType (context, nested, rootVisibility);
 
-			context.Annotations.Pop ();
+			context.Dependencies.Pop ();
 		}
 
 		void ProcessExecutable (AssemblyDefinition assembly)
 		{
 			SetAction (Context, assembly, AssemblyAction.Link);
 
-			Annotations.Push (assembly);
+			Dependencies.Push (assembly);
 
 			Annotations.Mark (assembly.EntryPoint.DeclaringType);
 
 			MarkMethod (Context, assembly.EntryPoint, MethodAction.Parse, RootVisibility.Any);
 
-			Annotations.Pop ();
+			Dependencies.Pop ();
 		}
 
 		static void MarkFields (LinkContext context, Collection<FieldDefinition> fields, RootVisibility rootVisibility)

--- a/linker/Mono.Linker.csproj
+++ b/linker/Mono.Linker.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="14.0">
   <!--
       TODO: Remove this workaround once supported.
@@ -72,6 +72,7 @@
     <Compile Include="Mono.Linker.Steps\CleanStep.cs" />
     <Compile Include="Mono.Linker.Steps\RegenerateGuidStep.cs" />
     <Compile Include="Mono.Linker.Steps\LoadI18nAssemblies.cs" />
+    <Compile Include="Mono.Linker\Dependencies.cs" />
     <Compile Include="Mono.Linker\IXApiVisitor.cs" />
     <Compile Include="Mono.Linker\I18nAssemblies.cs" />
     <Compile Include="Mono.Linker.Steps\IStep.cs" />

--- a/linker/Mono.Linker/Annotations.cs
+++ b/linker/Mono.Linker/Annotations.cs
@@ -52,31 +52,8 @@ namespace Mono.Linker {
 		readonly Dictionary<object, Dictionary<IMetadataTokenProvider, object>> custom_annotations = new Dictionary<object, Dictionary<IMetadataTokenProvider, object>> ();
 		readonly Dictionary<AssemblyDefinition, HashSet<string>> resources_to_remove = new Dictionary<AssemblyDefinition, HashSet<string>> ();
 
-		Stack<object> dependency_stack;
-		System.Xml.XmlWriter writer;
-		GZipStream zipStream;
-
-		public void PrepareDependenciesDump ()
-		{
-			PrepareDependenciesDump ("linker-dependencies.xml.gz");
-		}
-
-		public void PrepareDependenciesDump (string filename)
-		{
-			dependency_stack = new Stack<object> ();
-			System.Xml.XmlWriterSettings settings = new System.Xml.XmlWriterSettings();
-			settings.Indent = true;
-			settings.IndentChars = "\t";
-			var depsFile = File.OpenWrite (filename);
-			zipStream = new GZipStream (depsFile, CompressionMode.Compress);
-
-			writer = System.Xml.XmlWriter.Create (zipStream, settings);
-			writer.WriteStartDocument ();
-			writer.WriteStartElement ("dependencies");
-			writer.WriteStartAttribute ("version");
-			writer.WriteString ("1.0");
-			writer.WriteEndAttribute ();
-		}
+		// HACK : Remove by Miek
+		public Dependencies Dependencies { get; set; }
 
 		public ICollection<AssemblyDefinition> GetAssemblies ()
 		{
@@ -119,7 +96,7 @@ namespace Mono.Linker {
 		public void Mark (IMetadataTokenProvider provider)
 		{
 			marked.Add (provider);
-			AddDependency (provider);
+			Dependencies.AddDependency(provider);
 		}
 
 		public bool IsMarked (IMetadataTokenProvider provider)
@@ -314,76 +291,6 @@ namespace Mono.Linker {
 			slots = new Dictionary<IMetadataTokenProvider, object> ();
 			custom_annotations.Add (key, slots);
 			return slots;
-		}
-
-		public void AddDirectDependency (object b, object e)
-		{
-			if (writer == null)
-				return;
-
-			writer.WriteStartElement ("edge");
-			writer.WriteAttributeString ("b", TokenString (b));
-			writer.WriteAttributeString ("e", TokenString (e));
-			writer.WriteEndElement ();
-		}
-
-		public void AddDependency (object o)
-		{
-			if (writer == null)
-				return;
-
-			KeyValuePair<object, object> pair = new KeyValuePair<object, object> (dependency_stack.Count > 0 ? dependency_stack.Peek () : null, o);
-			if (pair.Key != pair.Value)
-			{
-				writer.WriteStartElement ("edge");
-				writer.WriteAttributeString ("b", TokenString (pair.Key));
-				writer.WriteAttributeString ("e", TokenString (pair.Value));
-				writer.WriteEndElement ();
-			}
-		}
-
-		public void Push (object o)
-		{
-			if (writer == null)
-				return;
-
-			if (dependency_stack.Count > 0)
-				AddDependency (o);
-			dependency_stack.Push (o);
-		}
-
-		public void Pop ()
-		{
-			if (writer == null)
-				return;
-
-			dependency_stack.Pop ();
-		}
-
-		string TokenString (object o)
-		{
-			if (o == null)
-				return "N:null";
-
-			if (o is IMetadataTokenProvider)
-				return (o as IMetadataTokenProvider).MetadataToken.TokenType + ":" + o;
-
-			return "Other:" + o;
-		}
-
-		public void SaveDependencies ()
-		{
-			if (writer == null)
-				return;
-
-			writer.WriteEndElement ();
-			writer.WriteEndDocument ();
-			writer.Flush ();
-			writer.Dispose ();
-			zipStream.Dispose ();
-			writer = null;
-			zipStream = null;
-			dependency_stack = null;
 		}
 	}
 }

--- a/linker/Mono.Linker/Dependencies.cs
+++ b/linker/Mono.Linker/Dependencies.cs
@@ -1,0 +1,274 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Mono.Cecil;
+using Mono.Linker.Steps;
+
+namespace Mono.Linker
+{
+	public class Dependencies
+	{
+		protected readonly LinkContext _context;
+		Stack<object> dependency_stack;
+		System.Xml.XmlWriter writer;
+		GZipStream zipStream;
+
+		public Dependencies(LinkContext context)
+		{
+			_context = context;
+		}
+
+		public void PrepareDependenciesDump()
+		{
+			PrepareDependenciesDump("linker-dependencies.xml.gz");
+		}
+
+		public void PrepareDependenciesDump(string filename)
+		{
+			dependency_stack = new Stack<object>();
+			System.Xml.XmlWriterSettings settings = new System.Xml.XmlWriterSettings();
+			settings.Indent = true;
+			settings.IndentChars = "\t";
+			var depsFile = File.OpenWrite(filename);
+			zipStream = new GZipStream(depsFile, CompressionMode.Compress);
+
+			writer = System.Xml.XmlWriter.Create(zipStream, settings);
+			writer.WriteStartDocument();
+			writer.WriteStartElement("dependencies");
+			writer.WriteStartAttribute("version");
+			writer.WriteString("1.0");
+			writer.WriteEndAttribute();
+		}
+
+		public IDisposable BeginScope(TypeDefinition definition)
+		{
+			Push(definition);
+			return new DependencyScope(this);
+		}
+
+		public IDisposable BeginScope(AssemblyDefinition definition)
+		{
+			Push(definition);
+			return new DependencyScope(this);
+		}
+
+		public IDisposable BeginScope(IMemberDefinition definition)
+		{
+			Push(definition);
+			return new DependencyScope(this);
+		}
+
+		public IDisposable BeginScope(IStep step)
+		{
+			Push(step);
+			return new DependencyScope(this);
+		}
+
+		public void AddDirectDependency(object b, object e)
+		{
+			if (writer == null)
+				return;
+
+			if (!ShouldRecordDependencyInformation(b) & !ShouldRecordDependencyInformation(e))
+				return;
+
+			WriteEdge(b, e);
+		}
+
+		public void AddDependency(object o)
+		{
+			if (writer == null)
+				return;
+
+			KeyValuePair<object, object> pair = new KeyValuePair<object, object>(dependency_stack.Count > 0 ? dependency_stack.Peek() : null, o);
+
+			if (!ShouldRecordDependencyInformation(pair.Key) & !ShouldRecordDependencyInformation(pair.Value))
+				return;
+
+			if (pair.Key != pair.Value)
+			{
+				WriteEdge(pair.Key, pair.Value);
+			}
+		}
+
+		public void Push(TypeDefinition definition)
+		{
+			if (writer == null)
+				return;
+
+			if (!WillAssemblyBeModified(definition.Module.Assembly))
+				return;
+
+			PushPrivate(definition);
+		}
+
+		public void Push(AssemblyDefinition definition)
+		{
+			if (writer == null)
+				return;
+
+			if (!WillAssemblyBeModified(definition))
+				return;
+
+			PushPrivate(definition);
+		}
+
+		public void Push(IMemberDefinition definition)
+		{
+			if (writer == null)
+				return;
+
+			if (!WillAssemblyBeModified(definition.DeclaringType.Module.Assembly))
+				return;
+
+			PushPrivate(definition);
+		}
+
+		public void Push(ICustomAttributeProvider provider)
+		{
+			if (writer == null)
+				return;
+
+			// TODO by Mike : Not sure what to do about this one
+			//if (!WillAssemblyBeModified(definition.DeclaringType.Module.Assembly))
+			//	return;
+
+			PushPrivate(provider);
+		}
+
+		public void Push(ExportedType exportedType)
+		{
+			if (writer == null)
+				return;
+
+			// TODO by Mike : Not sure what to do about this one
+			//if (!WillAssemblyBeModified(exportedType.DeclaringType.Module.Assembly))
+			//	return;
+
+			PushPrivate(exportedType);
+		}
+
+		public void Push(IStep step)
+		{
+			if (writer == null)
+				return;
+
+			PushPrivate(step);
+		}
+
+		public void Push(object o)
+		{
+			if (writer == null)
+				return;
+
+			PushPrivate(o);
+		}
+
+		public void Pop()
+		{
+			if (writer == null)
+				return;
+
+			dependency_stack.Pop();
+		}
+
+		public void SaveDependencies()
+		{
+			if (writer == null)
+				return;
+
+			writer.WriteEndElement();
+			writer.WriteEndDocument();
+			writer.Flush();
+			writer.Dispose();
+			zipStream.Dispose();
+			writer = null;
+			zipStream = null;
+			dependency_stack = null;
+		}
+
+		void PushPrivate(object o)
+		{
+			if (dependency_stack.Count > 0)
+				AddDependency(o);
+			dependency_stack.Push(o);
+		}
+
+		void WriteEdge(object b, object e)
+		{
+			writer.WriteStartElement("edge");
+			writer.WriteAttributeString("b", TokenString(b));
+			writer.WriteAttributeString("e", TokenString(e));
+			writer.WriteEndElement();
+		}
+
+		string TokenString(object o)
+		{
+			if (o == null)
+				return "N:null";
+
+			if (o is IMetadataTokenProvider)
+				return (o as IMetadataTokenProvider).MetadataToken.TokenType + ":" + o;
+
+			return "Other:" + o;
+		}
+
+		bool WillAssemblyBeModified(AssemblyDefinition assembly)
+		{
+			// TODO by Mike : Should other values be considered true?
+			return _context.Annotations.GetAction(assembly) == AssemblyAction.Link;
+		}
+
+		bool ShouldRecordDependencyInformation(object o)
+		{
+			if (o.ToString().Contains("WriteLine"))
+				Console.WriteLine();
+
+			if (o is TypeDefinition t)
+			{
+				return _context.Annotations.GetAction(t.Module.Assembly) == AssemblyAction.Link;
+			}
+
+			if (o is IMemberDefinition m)
+			{
+				return _context.Annotations.GetAction(m.DeclaringType.Module.Assembly) == AssemblyAction.Link;
+			}
+
+			if (o is TypeReference typeRef)
+			{
+				return _context.Annotations.GetAction(typeRef.Resolve().Module.Assembly) == AssemblyAction.Link;
+			}
+
+			if (o is MemberReference mRef)
+			{
+				return _context.Annotations.GetAction(mRef.Resolve().DeclaringType.Module.Assembly) == AssemblyAction.Link;
+			}
+
+			if (o is ModuleDefinition module)
+			{
+				return _context.Annotations.GetAction(module.Assembly) == AssemblyAction.Link;
+			}
+
+			return true;
+		}
+
+		class DependencyScope : IDisposable
+		{
+			private readonly Dependencies _parent;
+
+			public DependencyScope(Dependencies parent)
+			{
+				_parent = parent;
+			}
+
+			public void Dispose()
+			{
+				_parent.Pop();
+			}
+		}
+	}
+}

--- a/linker/Mono.Linker/LinkContext.cs
+++ b/linker/Mono.Linker/LinkContext.cs
@@ -129,6 +129,8 @@ namespace Mono.Linker {
 
 		public MarkingHelpers MarkingHelpers { get; private set; }
 
+		public Dependencies Dependencies { get; }
+
 		public LinkContext (Pipeline pipeline)
 			: this (pipeline, new AssemblyResolver ())
 		{
@@ -152,6 +154,8 @@ namespace Mono.Linker {
 			_annotations = annotations;
 			_readerParameters = readerParameters;
 			MarkingHelpers = CreateMarkingHelpers ();
+			Dependencies = CreateDependencies ();
+			_annotations.Dependencies = Dependencies;
 		}
 
 		public TypeDefinition GetType (string fullName)
@@ -334,6 +338,11 @@ namespace Mono.Linker {
 		protected virtual MarkingHelpers CreateMarkingHelpers ()
 		{
 			return new MarkingHelpers (this);
+		}
+
+		protected virtual Dependencies CreateDependencies ()
+		{
+			return new Dependencies (this);
 		}
 	}
 }

--- a/linker/Mono.Linker/Pipeline.cs
+++ b/linker/Mono.Linker/Pipeline.cs
@@ -123,9 +123,9 @@ namespace Mono.Linker {
 		{
 			while (_steps.Count > 0) {
 				IStep step = _steps [0];
-				context.Annotations.Push (step);
+				context.Dependencies.Push (step);
 				step.Process (context);
-				context.Annotations.Pop ();
+				context.Dependencies.Pop ();
 				_steps.Remove (step);
 			}
 		}


### PR DESCRIPTION
* Pull dependency stuff out of Annotations so that it has some room to grow without causing Annotations to become cluttered

* Experiment with ways to trim down the <edges> that are recorded.  My motivation is for testing.  When I get to testing the dependencies, it will be helpful to have output that only lists the test assembly so that you can easily see and understand what code causes what to be recorded.

My first thought was to add an option to skip writing <edges> for class libraries.  Then I thought, for the most part, if an assembly isn't going to be linked then you probably don't care about the reporting of edges in that assembly.   So that is the logic I have in here now.  It's not perfect, you could call into an assembly that is not linked and then it could call back into an assembly that is linked and in those cases you would be missing some information.  To deal with that I was thinking either

a) Make this an opt-in feature that is only turned on during our future dependency reporting tests
b) It's probably possible to queue up the info and only write it if we transition back into a linked assembly.  But I'm not sure this is worth the added complexity.  

* Another change in here is establishing a using(){} pattern to handle Push/Pop instead of what we have today.  Today it's a lot of adhoc push & pop that could easily get messed up and in some places we have try/push/finally/push which is a better but not as clean as a using() in my opinion.

My goal will be to move most code over to the using() pattern, but I'm sure some will have to remain as adhoc Push & Pop.